### PR TITLE
Update Cromwell config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Configuration file templates to run WDL workflows with Cromwell
 
-[Cromwell](https://cromwell.readthedocs.io/) is a tool to execute workflows written in [WDL](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md) language, locally or using Google Cloud.
+[Cromwell](https://cromwell.readthedocs.io/) is a tool used to execute
+workflows written in [WDL](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md)
+(Workflow Description Language). These workflows can be executed in a local,
+HPC, or cloud (e.g. GCP) environment.
 
 To install Cromwell, you can use conda:
 
@@ -9,13 +12,11 @@ create -n cromwell -c conda-forge cromwell
 conda activate cromwell
 ```
 
-Cromwell takes 2 configuration files on input: `cromwell.conf` and `options.json`. We provide templates for both files, which are suitable for running workflows using [Google Cloud Life Sciences](https://cromwell.readthedocs.io/en/stable/tutorials/PipelinesApi101/) (previously known as PAPI - Pipelines API).
-
-To run Cromwell, first edit `cromwell.template.conf` to replace the following values in angle brackets:
-
-* `<project>`: the Google Cloud project name
-* `<bucket>`: a Google Cloud Storage bucket name to store executions
-* (optional) `<mysql-password>`: MySQL password for a locally running MySQL server that will be used to track Cromwell executions in order to allow restarts of incomplete runs. You can comment out the entire `database` section if you don't need that functionality.
+Cromwell can be configured via two files passed to the `-Dconfig.file` and `--options`
+command line arguments. We provide templates for both files, which are suitable
+for running workflows on Google Cloud using
+[Google Cloud Life Sciences](https://cromwell.readthedocs.io/en/stable/tutorials/PipelinesApi101/)
+(previously known as PAPI - Pipelines API).
 
 **Important**: Make sure to schedule your VM workers in a region that's
 colocated with your data buckets, to avoid incurring high network egress
@@ -23,17 +24,25 @@ costs. Don't move large files like BAMs between continents: copying 1 TB of
 data from the US to Australia costs 190 USD. Adjust the `default-zones`
 attribute in the template if necessary.
 
+To run Cromwell, first edit `cromwell.template.conf` to replace the following values in angle brackets:
+
+* `<project>`: the Google Cloud project name.
+* `<bucket>`: a Google Cloud Storage bucket name to store executions.
+* (optional) `<mysql-password>`: MySQL password for a locally running MySQL server that will be used to track Cromwell executions in order to allow restarts of incomplete runs. You can comment out the entire `database` section if you don't need that functionality.
+
 Also edit `options.template.json`:
 
-* `<bucket>`: a Google Cloud Storage bucket name to store outputs out successfully finished executions
+* `<bucket>`: a Google Cloud Storage bucket name to store outputs of successfully finished executions
 
-Finally, to run a workflow `workflow.wdl` with inputs in `inputs.json`, use the following command (assuming the edited configuration files are saved under `cromwell.conf` and `options.json`).
+Finally, to run a workflow `workflow.wdl` with inputs in `inputs.json`, use the following command (assuming the edited configuration files are saved under `cromwell.conf` and `options.json`):
 
 ```
 cromwell -Dconfig.file=cromwell.conf run workflow.wdl --inputs inputs.json --options options.json &
 ```
 
-Make sure to keep `&` in the end to run the process in the background, otherwise you might accidentally interrupt the execution. To bring the process to the foreground, so you could interrupt it, run `fg`.
+Make sure to keep `&` in the end to run the process in the background,
+otherwise you might accidentally interrupt the execution.
+Use `fg` to bring the process back to the foreground.
 
 ## WARP inputs
 
@@ -44,12 +53,12 @@ The `warp-inputs/` folder contains templates that can be modified to use with [W
 To run a [WES germline variant calling WDL workflow](https://github.com/populationgenomics/warp/blob/start_from_mapped_bam/pipelines/broad/dna_seq/germline/single_sample/) (which is based on [Broad WARP](https://github.com/broadinstitute/warp/)) on a sample NA12878 using the data from `gs://genomics-public-data`, run the following commands:
 
 ```
-git clone https://github.com/populationgenomics/cpg-fewgenomes
+git clone https://github.com/populationgenomics/fewgenomes
 git clone https://github.com/populationgenomics/warp
 SAMPLE=NA12878
 cromwell -Dconfig.file=cromwell.conf run \
     warp/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeFromBam.wdl \ 
-    --inputs cpg-fewgenomes/datasets/toy/exome_bam/$SAMPLE.json \
+    --inputs fewgenomes/datasets/toy/exome_bam/$SAMPLE.json \
     --options options.json
 ```
 

--- a/cromwell.template.conf
+++ b/cromwell.template.conf
@@ -24,7 +24,7 @@ backend {
       actor-factory = "cromwell.backend.google.pipelines.v2beta.PipelinesApiLifecycleActorFactory"
       config {
         # Google project
-        project = <project>
+        project = "<project>"
 
         # Base bucket for workflow executions
         root = "gs://<bucket>/cromwell/executions"
@@ -54,11 +54,6 @@ backend {
           # Note that this is only used to store metadata about the pipeline operation.
           # Worker VMs can be scheduled in any region (see default-zones).
           location = "us-central1"
-
-          # The zones to schedule worker VMs in. These should be colocated with
-          # the regions of your data buckets.
-          # https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#zones
-          default-zones = "australia-southeast1-a australia-southeast1-b australia-southeast1-c"
         }
 
         filesystems {
@@ -76,7 +71,12 @@ backend {
           # Allowed to be a String, or a list of Strings
           disks: "local-disk 10 SSD"
           noAddress: false
-          preemptible: 0
+          preemptible: 1
+
+          # The zones to schedule worker VMs in. These should be colocated with
+          # the regions of your data buckets.
+          # https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#zones
+          zones = "australia-southeast1-a australia-southeast1-b australia-southeast1-c"
         }
 
         reference-disk-localization-manifest-files = ["gs://gcp-public-data--broad-references/refdisk_manifest.json"]

--- a/cromwell.template.conf
+++ b/cromwell.template.conf
@@ -12,7 +12,7 @@ engine {
   filesystems {
     gcs {
       auth = "application_default"
-      project = "vlad-dev"
+      project = "<project>"
     }
   }
 }


### PR DESCRIPTION
Was wondering why my VMs were running in the US. Turns out the `default-zones` is deprecated (at least with Cromwell v56). `zones` seems to work.
Also changed to use preemptible VMs by default - think that is the more cost-effective approach.
And made a few small changes in the README.
@vladsaveliev I think the `WARP inputs` part in the README needs updating, since I couldn't find those sample json files in those directories.

<img width="718" alt="Screen Shot 2021-02-14 at 11 57 28 pm" src="https://user-images.githubusercontent.com/29562861/107891114-c1994600-6f70-11eb-8e80-247ee786df75.png">
